### PR TITLE
Making the plugin variables optional

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
     xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="com.telerik.plugin.telerikanalytics"
-    version="3.4.0">
+    version="3.4.1">
 
   <dependency id="uk.co.whiteoctober.cordova.appversion" url="https://github.com/Telerik-Verified-Plugins/AppVersion" commit="master" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,9 +24,9 @@
     <clobbers target="plugins.EqatecAnalytics" />
   </js-module>
 
-  <preference name="PRODUCT_ID" />
-  <preference name="AUTO_TRACK_KENDO_EVENTS" />
-  <preference name="AUTO_TRACK_EXCEPTIONS" />
+  <preference name="PRODUCT_ID" default="YourKeyHere"/>
+  <preference name="AUTO_TRACK_KENDO_EVENTS" default="false"/>
+  <preference name="AUTO_TRACK_EXCEPTIONS" default="false"/>
 
   <!-- android -->
   <platform name="android">

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
     xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="com.telerik.plugin.telerikanalytics"
-    version="3.3.2">
+    version="3.4.0">
 
   <dependency id="uk.co.whiteoctober.cordova.appversion" url="https://github.com/Telerik-Verified-Plugins/AppVersion" commit="master" />
 

--- a/src/ios/EqatecAnalyticsPlugin.mm
+++ b/src/ios/EqatecAnalyticsPlugin.mm
@@ -477,7 +477,7 @@
 
   CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:values];
   NSString *callbackId = [command callbackId];
-  [self success:result callbackId:callbackId];
+  [self.commandDelegate sendPluginResult:result callbackId:callbackId];
 }
 
 // Release doesn't work for now!!!

--- a/www/EqatecAnalytics.js
+++ b/www/EqatecAnalytics.js
@@ -750,14 +750,16 @@ module.exports = EqatecAnalytics;
       cordova.getAppVersion(function (version) {
           cordova.exec(function(data) {
               var productId = data.productId;
-              var productVersion = version != null && version != 'N/A' ? version : null;
-              monitor.autoTrackKendoEvents = (data.autoTrackKendoEvents || '').toLowerCase() === 'true';
-              monitor.autoTrackExceptions = (data.autoTrackExceptions || '').toLowerCase() === 'true';
-              window.plugins.EqatecAnalytics.Factory.pluginVariables = {
-                  productId: productId,
-                  productVersion: productVersion
-              };
-              monitor.start(productId, productVersion);
+              if(productId !== "YourKeyHere"){
+                  var productVersion = version != null && version != 'N/A' ? version : null;
+                  monitor.autoTrackKendoEvents = (data.autoTrackKendoEvents || '').toLowerCase() === 'true';
+                  monitor.autoTrackExceptions = (data.autoTrackExceptions || '').toLowerCase() === 'true';
+                  window.plugins.EqatecAnalytics.Factory.pluginVariables = {
+                      productId: productId,
+                      productVersion: productVersion
+                  };
+                  monitor.start(productId, productVersion);
+              }
           }, function(err) {
               console.log('Unable to read required plugin variables: ' + err);
           }, 'EqatecAnalytics', 'GetVariables', [ 'productId', 'autoTrackKendoEvents', 'autoTrackExceptions' ]);


### PR DESCRIPTION
The 3 plugin variables are now made optional. If no values are specified, the plugin will not automatically start any Analytics session and this can be done using code.

Also fixed an issue with iOS builds with the latest Cordova version.
